### PR TITLE
fix(disable-no-init): correct bug occurring if carousel not initialized

### DIFF
--- a/main.js
+++ b/main.js
@@ -125,11 +125,14 @@ class Plugin {
 		this.nodes.wrapper.removeAttribute("style")
 
 		this.nodes.items.forEach((nodes) => {
-			nodes?.forEach((node) => {
-				node.removeAttribute("tabindex")
-				node.removeAttribute("aria-hidden")
-				node.removeAttribute("style")
-			})
+			// Items may have not been initialized yet.
+			if (Array.isArray(nodes)) {
+				nodes.forEach((node) => {
+					node.removeAttribute("tabindex")
+					node.removeAttribute("aria-hidden")
+					node.removeAttribute("style")
+				})
+			}
 		})
 
 		this.el.classList.remove(ACTIVECLASS)


### PR DESCRIPTION
If for some reason, the carousel is not first initialized, the `reinit()` method which calls the `disable()` method will crash.
For example, here is a setting to put on a carousel : 
```json
{
    "default": {
        "disable": true
    },
    "responsive": [
        {
            "minWidth": "1920px",
            "disable": true
        },
        {
            "minWidth": "768px",
            "disable": false
        }
    ]
}
```

If you load the carousel on desktop with a 1920px width, it will not load (which is what we want), then if you reduce the width of the window to 768px, once the eventListener tries to trigger a `reinit()`, JS will crash because `nodes` at this point are DOM elements instead of expected arrays.