### PR TITLE
feat(disable-auto): add a new auto mode for disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,14 @@ Both methods can be called again when new carousels are injected into the DOM.
 
 ## Responsive settings
 
-Have you noticed the `reponsive` key in the above example? That's the way to make your carousel fully responsive.
+Have you noticed the `reponsive` key in the above example?
+That's the way to make your carousel fully responsive.
 
 You can use whatever unit you want for the `minWidth` setting.
 
 The `disable` setting will deactivate the carousel.
+If set to `auto`, the carousel will only be enabled
+when the total number of items is greater than the group size.
 
 ## API
 
@@ -240,7 +243,7 @@ The instance of `pm-carousel` can be reached from nodes with `data-pm-carousel` 
 
 ### Play and Stop
 
-Only available when Play/PAuse button is present.
+Only available when Play/Pause button is present.
 
 ```JS
 const myCarousel = document.querySelector(".class-of-a-carousel");

--- a/main.js
+++ b/main.js
@@ -26,7 +26,13 @@ class Plugin {
 
 		addEvents.call(this)
 
-		if (!this.currentSettings.disable) {
+		if (
+			!(
+				this.currentSettings.disable === true ||
+				(this.currentSettings.disable === "auto" &&
+					this.currentSettings.group >= this.nodes.size)
+			)
+		) {
 			init.call(this)
 		}
 	}

--- a/src/getConfig.js
+++ b/src/getConfig.js
@@ -40,7 +40,16 @@ function getConfig(settings = {}) {
 		timeout = setTimeout(() => {
 			this.currentSettings = getMqConfig.call(this)
 
-			this.currentSettings.disable ? this.disable() : this.reinit()
+			if (
+				this.currentSettings.disable === true ||
+				(this.currentSettings.disable === "auto" &&
+					this.currentSettings.group >= this.nodes.size)
+			) {
+				this.disable()
+			}
+			else {
+				this.reinit()
+			}
 
 			checkDebounce = false
 			clearTimeout(timeout)

--- a/src/getNodes.js
+++ b/src/getNodes.js
@@ -9,7 +9,7 @@ import {
 } from "./constants"
 
 function getNodes() {
-	return {
+	const nodes = {
 		paging: this.el.querySelector(`[${ATTRPAGING}]`),
 		prev: this.el.querySelector(`[${ATTRPREV}]`),
 		next: this.el.querySelector(`[${ATTRNEXT}]`),
@@ -18,6 +18,8 @@ function getNodes() {
 		wrapper: this.el.querySelector(`[${ATTRWRAPPER}]`),
 		items: [...this.el.querySelectorAll(`[${ATTRITEM}]`)],
 	}
+	nodes.size = nodes.items.length
+	return nodes
 }
 
 export default getNodes


### PR DESCRIPTION
Currently if there are fewer items in a carousel than what is declared in the `group` variable in its settings, the carousel is still activated. I think it would be an interesting feature if we could deactivate the carousel in this specific case by adding an autodisable mode, without changing the original behaviors and keeping a retrocompatibility.